### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "mattes/wp-cli-git-command",
-    "type": "command",
+    "type": "wp-cli-package",
     "description": "WordPress Git helpers, like pre-commit hooks for automatic MySQL database dumps.",
     "keywords": ["wp-cli", "git", "mysql", "dump", "wordpress"],
     "homepage": "https://github.com/mattes/wp-cli-git-command",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
